### PR TITLE
Don't use obsoleted function

### DIFF
--- a/multi-compile.el
+++ b/multi-compile.el
@@ -194,11 +194,11 @@
 (defun multi-compile--get-command-template ()
   (let ((filename (if (stringp buffer-file-name) buffer-file-name (buffer-name))))
     (if (not filename)
-        (read-input "Compile command: ")
+        (read-string "Compile command: ")
       (let ((command-list (multi-compile--fill-command-list filename)))
         (if command-list
             (multi-compile--choice-compile-command command-list)
-          (read-input "Compile command: "))))))
+          (read-string "Compile command: "))))))
 
 ;;;###autoload
 (defun multi-compile-locate-file-dir (name)


### PR DESCRIPTION
read-input was obsoleted since Emacs 22. It is an alias of read-string
from Emacs 23. And using read-input causes byte-compile warnings as below.

```
multi-compile.el:196:14:Warning: `read-input' is an obsolete function (as of
    22.1); use `read-string' instead.                                                                           
multi-compile.el:200:52:Warning: `read-input' is an obsolete function (as of
    22.1); use `read-string' instead.
```