### PR TITLE
Use compile instead of compilation-start.

### DIFF
--- a/multi-compile.el
+++ b/multi-compile.el
@@ -259,7 +259,7 @@
   (let* ((template (multi-compile--get-command-template))
          (command (or (car-safe template) template))
          (default-directory (if (listp template) (eval-expression (cadr template)) default-directory)))
-    (compilation-start
+    (compile
      (multi-compile--fill-template command))))
 
 (multi-compile--load-hostory)


### PR DESCRIPTION
That way `compile-command` will be set, allowing multi-compile to work with `recompile`.