### PR TITLE
Update to support older versions of Emacs.

### DIFF
--- a/multi-compile.el
+++ b/multi-compile.el
@@ -8,7 +8,7 @@
 ;; Package-Version: 20160215.1219
 ;; Keywords: tools compile build
 ;; URL: https://github.com/ReanGD/emacs-multi-compile
-;; Package-Requires: ((emacs "24") (dash "2.12.1"))
+;; Package-Requires: ((emacs "24.4") (dash "2.12.1"))
 ;;
 ;; This file is not part of GNU Emacs.
 ;;
@@ -90,6 +90,10 @@
 ;;; Code:
 (require 'dash)
 (require 'compile)
+
+(eval-when-compile
+  ;; string-join
+  (require 'subr-x))
 
 (defgroup multi-compile nil
   "Multi target interface to `compile'."
@@ -343,7 +347,7 @@
          (command (or (car-safe template) template))
          ;; The command may be either a string or a list of strings to be joined by a space.
          ;; The canonical form is just a string where any joining has already been performed.
-         (canonical-command (string-join (flatten-list (list command)) " "))
+         (canonical-command (string-join (-flatten command) " "))
          (default-directory (or (and (listp template)
                                      (> (length template) 1)
                                      (eval-expression (cadr template)))


### PR DESCRIPTION
Updated Emacs version dependency.  Specific functions in use in the package were introduced after Emacs 24 (such as "user-error" in Emacs 24.3).  Therefore, updated the Emacs version to more accurately reflect the minimum version required.

Replaced the usage of "flatten-list" with the Dash "-flatten" equivalent.  The built-in "flatten-list" function was introduced in Emacs 27.1, however this unnecessarily bumps the minimum version of Emacs required to a much more recent version.  Multi-Compile is already dependent on Dash and it already contains equivalent functionality, so that is used instead to remain compatible with older versions of Emacs.

Added compile-time "require" of the "subr-x" package.  This package contains the macro definition for "string-join".  This doesn't seem necessary in newer versions of Emacs (probably because internal functionality has a dependency on it and thus requires it), but was required when used with older versions of Emacs (e.g., Emacs 25.3.1).