### PR TITLE
Fix symbol's value is void error

### DIFF
--- a/multi-compile.el
+++ b/multi-compile.el
@@ -271,7 +271,7 @@
   ;; next iteration of the loop and then be expanded.  We keep repeating this as long as at
   ;; least one expansion occurs in a loop iteration.
   (cl-loop
-   with function-expanded
+   with function-expanded = nil
    do
    (setq function-expanded nil)
    (dolist (template multi-compile-template)


### PR DESCRIPTION
I'm not sure if it's a proper fix, but this change makes the error `Symbol's value as variable is void: width` disappear when trying to execute a compile command after choosing one entry with `multi-compile-run`. (emacs 27.2).

Thanks for this very convenient package, BTW.