### PR TITLE
add melpa badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![MELPA](https://melpa.org/packages/multi-compile-badge.svg)](https://melpa.org/#/multi-compile)
+
 # multi-compile
 Multi target interface to compile.
 


### PR DESCRIPTION
The badge just makes it very clear to anyone looking at this in github that it's in melpa so they don't necessarily need to install manually.